### PR TITLE
Handle null/undefined return from .map() mapper function

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -64,8 +64,8 @@ class PresentOptional<T> extends Optional<T> {
         return (predicate(this.payload)) ? this : Optional.empty();
     }
 
-    map<U>(mapper: (value: T) => U): Optional<U> {
-        return Optional.ofNonNull(mapper(this.payload));
+    map<U>(mapper: (value: T) => U | null | undefined): Optional<U> {
+        return Optional.ofNullable(mapper(this.payload));
     }
     
     flatMap<U>(mapper: (value: T) => Optional<U>): Optional<U> {

--- a/test/OptionalTest.ts
+++ b/test/OptionalTest.ts
@@ -128,6 +128,17 @@ describe("Optional", () => {
             let actual = sutEmpty.map(mapper);
             assert(actual.isEmpty);
         });
+
+        it("handle null/undefined mapper return value properly", () => {
+            const payload = {
+                a: "A"
+            };
+            assert.equal(payload.a, Optional.ofNonNull(payload).map(p => p.a).get());
+
+            const fallback = "B";
+            assert.equal(fallback, Optional.ofNonNull(payload as any).map(p => p.b).orElse(fallback));
+            assert.equal(fallback, Optional.ofNonNull(payload).map(p => null as any).orElse(fallback));
+        })
     });
 
     describe("#flatMap", () => {


### PR DESCRIPTION
Java implementation of Optional properly handles null, returned by
mapper function, which allows to implement something like that with as
little boilerplate as possible:
```java
return Optional.ofNullable(email)
                        .map(this::getDomainFromEmail)
                        .map(SomeRepository::findFirstByDomain)
                        .map(SomeEntity::getSomeAttribute)
                        .map(ResponseEntity::ok)
                        .orElseGet(() -> ResponseEntity.notFound().build())
```