### PR TITLE
Accept possible undefined return value in map with correct return type.

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,8 @@
 import { Option, Cases } from "./types";
 
+type Diff<T, U> = T extends U ? never : T;  // Remove types from T that are assignable to U
+type NonNullable<T> = Diff<T, null | undefined>;  // Remove null and undefined from T
+
 /**
  * `Optional` (like Java) implementation in TypeScript.
  * 
@@ -76,7 +79,7 @@ export default abstract class Optional<T> {
      * 
      * @param mapper a mapper to apply the payload, if present
      */
-    abstract map<U> (mapper: (value: T) => U): Optional<U>;
+    abstract map<U> (mapper: (value: T) => NonNullable<U> | null | undefined): Optional<U>;
     
     /**
      * Maps a payload with a mapper which returns Optional as a result.
@@ -233,7 +236,7 @@ class PresentOptional<T> extends Optional<T> {
         return (predicate(this.payload)) ? this : Optional.empty();
     }
 
-    map<U>(mapper: (value: T) => U | null | undefined): Optional<U> {
+    map<U>(mapper: (value: T) => NonNullable<U> | null | undefined): Optional<U> {
         return Optional.ofNullable(mapper(this.payload));
     }
     
@@ -298,7 +301,7 @@ class EmptyOptional<T> extends Optional<T> {
         return this;
     }
 
-    map<U>(mapper: (value: T) => U): Optional<U> {
+    map<U>(mapper: (value: T) => U | null | undefined): Optional<U> {
         return Optional.empty();
     }
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -79,7 +79,7 @@ export default abstract class Optional<T> {
      * 
      * @param mapper a mapper to apply the payload, if present
      */
-    abstract map<U> (mapper: (value: T) => NonNullable<U> | null | undefined): Optional<U>;
+    abstract map<U> (mapper: (value: T) => U): Optional<NonNullable<U>>;
     
     /**
      * Maps a payload with a mapper which returns Optional as a result.
@@ -236,7 +236,7 @@ class PresentOptional<T> extends Optional<T> {
         return (predicate(this.payload)) ? this : Optional.empty();
     }
 
-    map<U>(mapper: (value: T) => NonNullable<U> | null | undefined): Optional<U> {
+    map<U>(mapper: (value: T) => NonNullable<U>): Optional<NonNullable<U>> {
         return Optional.ofNullable(mapper(this.payload));
     }
     
@@ -301,7 +301,7 @@ class EmptyOptional<T> extends Optional<T> {
         return this;
     }
 
-    map<U>(mapper: (value: T) => U | null | undefined): Optional<U> {
+    map<U>(mapper: (value: T) => U): Optional<NonNullable<U>> {
         return Optional.empty();
     }
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,8 +1,5 @@
 import { Option, Cases } from "./types";
 
-type Diff<T, U> = T extends U ? never : T;  // Remove types from T that are assignable to U
-type NonNullable<T> = Diff<T, null | undefined>;  // Remove null and undefined from T
-
 /**
  * `Optional` (like Java) implementation in TypeScript.
  * 
@@ -236,8 +233,9 @@ class PresentOptional<T> extends Optional<T> {
         return (predicate(this.payload)) ? this : Optional.empty();
     }
 
-    map<U>(mapper: (value: T) => NonNullable<U>): Optional<NonNullable<U>> {
-        return Optional.ofNullable(mapper(this.payload));
+    map<U>(mapper: (value: T) => U): Optional<NonNullable<U>> {
+        let result : U = mapper(this.payload);
+        return Optional.ofNullable(result!);
     }
     
     flatMap<U>(mapper: (value: T) => Optional<U>): Optional<U> {

--- a/test/OptionalTest.ts
+++ b/test/OptionalTest.ts
@@ -198,9 +198,12 @@ describe("Optional", () => {
             };
             assert.strictEqual(payload.a, Optional.ofNonNull(payload).map(p => p.a).get());
 
+            const mapper : (x:boolean) => undefined|number = (isNull : boolean) => isNull ? undefined : 1;
+
             const fallback = "B";
             assert.strictEqual(fallback, Optional.ofNonNull(payload as any).map(p => p.b).orElse(fallback));
             assert.strictEqual(fallback, Optional.ofNonNull(payload).map(p => null as any).orElse(fallback));
+            assert.strictEqual(fallback, Optional.ofNonNull(payload as any).map(p => mapper(true)).orElse(fallback));
         })
     });
 

--- a/test/OptionalTest.ts
+++ b/test/OptionalTest.ts
@@ -193,17 +193,27 @@ describe("Optional", () => {
         });
 
         it("should handle null/undefined mapper return value properly", () => {
-            const payload = {
+            interface Payload {
+                a: string;
+            }
+
+            const payload : Payload = {
                 a: "A"
             };
             assert.strictEqual(payload.a, Optional.ofNonNull(payload).map(p => p.a).get());
 
-            const mapper : (x:boolean) => undefined|number = (isNull : boolean) => isNull ? undefined : 1;
-
             const fallback = "B";
             assert.strictEqual(fallback, Optional.ofNonNull(payload as any).map(p => p.b).orElse(fallback));
             assert.strictEqual(fallback, Optional.ofNonNull(payload).map(p => null as any).orElse(fallback));
-            assert.strictEqual(fallback, Optional.ofNonNull(payload as any).map(p => mapper(true)).orElse(fallback));
+
+            const mapper : (x:boolean) => undefined|Payload = (isNull : boolean) => isNull ? undefined : payload;
+
+            const fallbackPayload = {
+                a: "B"
+            };
+
+            assert.strictEqual(fallbackPayload, Optional.ofNonNull(payload).map(p => mapper(true)).orElse(fallbackPayload));
+            assert.strictEqual(payload.a, Optional.ofNonNull(payload).map(p => mapper(false)).map(x => x.a).get());
         })
     });
 


### PR DESCRIPTION
Hi there,
I noticed that the following code would result in a somewhat odd generic type:

```
const mapper : (x:boolean) => undefined|number = (isNull : boolean) => isNull ? undefined : 1;
let result : Optional<number|undefined> = Optional.of(1).map(x => mapper(true));
```

I would expect to receive a `Optional<number>`, not a `Optional<number|undefined>`.

This should fix that issue by forbidding the generic type U to become undefined | null