### PR TITLE
Fix type in doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ optional.map(value => value.length);
 // map a payload with the given mapper which returns value wrapped with Optional type.
 const powerIfPositive: (x: Number) => Optional<Number>
     = x => (x > 0) ? Optional.ofNonNull(x * x) : Optional.empty();
-const numberOptional: Optional<number> = Optional.ofNullable(/* some optional value: null | number */)
-numberOptional.flatMap(value => powerIfPositive(value));
+const numberOptional: Optional<null | number> = Optional.ofNullable(/* some optional value: null | number */)
+numberOptional.flatMap(value => powerIfPositive(value as number));
 
 // if this is present, return this, otherwise return the given another optional.
 const another: Optional<string> = Optional.ofNullable(/* ... */);


### PR DESCRIPTION
Hi,

i have this error : ```  Type 'null' is not assignable to type 'number'.``` when i follow the comment in the example and create a code like this: ```const numberOptional: Optional<number> = Optional.ofNullable(null);

const result = numberOptional.flatMap(value => powerIfPositive(value)); ```. 

I hope this PR fix the problem or maybe i don't really understand the comment in the documentation. Please let me know.

Thanks !

